### PR TITLE
Add benchmark

### DIFF
--- a/Tests/benchmarktests.py
+++ b/Tests/benchmarktests.py
@@ -1,0 +1,23 @@
+import benchmark
+import unittest
+
+
+class TestCaseTests(unittest.TestCase):
+    def test_case_generates(self):
+        dictionary = ["word"]
+        test_cases = benchmark.generate_test_cases(dictionary, 1)
+        self.assertEqual(len(test_cases), 1)
+        self.assertEqual(test_cases[0][0], "word")
+        self.assertEqual(test_cases[0][1], "word")
+
+    def test_multiple_test_cases(self):
+        dictionary = ["first", "second", "third", "fourth"]
+        test_cases = benchmark.generate_test_cases(dictionary, 3)
+        self.assertEqual(len(test_cases), 3)
+        for test_case in test_cases:
+            self.assertIn(test_case[0], dictionary)
+            self.assertIn(test_case[1], dictionary)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/Tests/tests.py
+++ b/Tests/tests.py
@@ -126,6 +126,11 @@ class FullAlgorithmTests(unittest.TestCase):
         result = chainAlgorithm.get_chain("hello", "hello", ["hello"])
         self.assertEqual(len(result), 1)
 
+    def test_dictionary_preserved(self):
+        dictionary = ["hope", "hose", "host", "distraction"]
+        chainAlgorithm.get_chain("hope", "host", dictionary)
+        self.assertEqual(len(dictionary), 4)
+
 
 class LevenshteinDistanceTests(unittest.TestCase):
     def test_zero_distance(self):
@@ -151,6 +156,20 @@ class LevenshteinDistanceTests(unittest.TestCase):
     def test_change_and_remove(self):
         result = chainAlgorithm.get_levenshtein_distance("hope", "hip")
         self.assertEqual(result, 2)
+
+
+class StandardBfsTests(unittest.TestCase):
+    def test_chain_found(self):
+        result = chainAlgorithm.standard_bfs("hope", "host", ["hope", "hose", "host", "distraction"])
+        self.assertEqual(len(result), 3)
+        self.assertEqual(result[0], "hope")
+        self.assertEqual(result[1], "hose")
+        self.assertEqual(result[2], "host")
+
+    def test_chain_impossible(self):
+        result = chainAlgorithm.standard_bfs("hello", "goodbye",
+                                          ["hello", "irrelevant", "random", "useless", "goodbye"])
+        self.assertEqual(len(result), 0)
 
 
 if __name__ == '__main__':

--- a/Tests/tests.py
+++ b/Tests/tests.py
@@ -158,19 +158,5 @@ class LevenshteinDistanceTests(unittest.TestCase):
         self.assertEqual(result, 2)
 
 
-class StandardBfsTests(unittest.TestCase):
-    def test_chain_found(self):
-        result = chainAlgorithm.standard_bfs("hope", "host", ["hope", "hose", "host", "distraction"])
-        self.assertEqual(len(result), 3)
-        self.assertEqual(result[0], "hope")
-        self.assertEqual(result[1], "hose")
-        self.assertEqual(result[2], "host")
-
-    def test_chain_impossible(self):
-        result = chainAlgorithm.standard_bfs("hello", "goodbye",
-                                          ["hello", "irrelevant", "random", "useless", "goodbye"])
-        self.assertEqual(len(result), 0)
-
-
 if __name__ == '__main__':
     unittest.main()

--- a/benchmark.py
+++ b/benchmark.py
@@ -5,6 +5,7 @@ import dictionaryParser
 
 
 def generate_test_cases(dictionary, test_count):
+    """Generates random pairs of words from the dictionary"""
     test_cases = []
     dictionary_size = len(dictionary)
     for _ in range(0, test_count):
@@ -15,6 +16,7 @@ def generate_test_cases(dictionary, test_count):
 
 
 def benchmark_function(function, dictionary, test_cases):
+    """Runs the chain function on all test cases, returning the avg and max times"""
     run_times = []
     max_run_time = 0
     total_run_time = 0
@@ -32,8 +34,8 @@ def benchmark_function(function, dictionary, test_cases):
 
 
 def run_benchmarks():
-    functions = [("Bidirectional BFS", chainAlgorithm.get_chain),
-                 ("Alphabetical optimization", chainAlgorithm.get_chain_A)]
+    """Benchmarks multiple functions on the same set of random test cases"""
+    functions = [("Bidirectional BFS", chainAlgorithm.get_chain)]
     dictionary = dictionaryParser.read_dictionary()
     test_count = 10
     test_cases = generate_test_cases(dictionary, test_count)

--- a/benchmark.py
+++ b/benchmark.py
@@ -1,0 +1,48 @@
+import random
+import time
+import chainAlgorithm
+import dictionaryParser
+
+
+def generate_test_cases(dictionary, test_count):
+    test_cases = []
+    dictionary_size = len(dictionary)
+    for _ in range(0, test_count):
+        start_word_index = random.randrange(0, dictionary_size)
+        end_word_index = random.randrange(0, dictionary_size)
+        test_cases.append((dictionary[start_word_index], dictionary[end_word_index]))
+    return test_cases
+
+
+def benchmark_function(function, dictionary, test_cases):
+    run_times = []
+    max_run_time = 0
+    total_run_time = 0
+    for test_case in test_cases:
+        run_start = time.perf_counter()
+        result = function(test_case[0], test_case[1], dictionary)
+        run_stop = time.perf_counter()
+        run_time = run_stop - run_start
+        total_run_time += run_time
+        if run_time > max_run_time:
+            max_run_time = run_time
+
+    avg_run_time = total_run_time / len(test_cases)
+    return avg_run_time, max_run_time
+
+
+def run_benchmarks():
+    functions = [("Bidirectional BFS", chainAlgorithm.get_chain),
+                 ("Alphabetical optimization", chainAlgorithm.get_chain_A)]
+    dictionary = dictionaryParser.read_dictionary()
+    test_count = 10
+    test_cases = generate_test_cases(dictionary, test_count)
+    for function in functions:
+        print(f"Running {function[0]}...")
+        benchmark_results = benchmark_function(function[1], dictionary, test_cases)
+        print(f"{function[0]} had an average time of {benchmark_results[0]:0.6f}s "
+              f"and a max time of {benchmark_results[1]:0.6f}s")
+
+
+if __name__ == '__main__':
+    run_benchmarks()

--- a/chainAlgorithm.py
+++ b/chainAlgorithm.py
@@ -4,9 +4,11 @@ def get_chain(start, end, dictionary):
     start -- the first word in the chain
     end -- the last word in the chain
     dictionary -- a list of strings which count as words"""
+    # Immediately short-circuit 1 length chains
     if start == end:
         return [start]
 
+    # Duplicate the dictionary so it can be modified safely
     remaining_dictionary = dictionary.copy()
 
     # bidirectional_bfs expects the words in current_nodes and target_nodes to not be in the dictionary
@@ -15,6 +17,7 @@ def get_chain(start, end, dictionary):
     if end in remaining_dictionary:
         remaining_dictionary.remove(end)
 
+    # Run the main algorithm
     chain = bidirectional_bfs([SearchNode(start)], [SearchNode(end)], remaining_dictionary)
 
     # Bidirectional nature means result may be in opposite order
@@ -46,80 +49,6 @@ def bidirectional_bfs(current_nodes, target_nodes, dictionary):
     return bidirectional_bfs(target_nodes, next_words, dictionary)
 
 
-def get_chain_A(start, end, dictionary):
-    """Finds a minimum length chain of words with only one character different between each link
-
-    start -- the first word in the chain
-    end -- the last word in the chain
-    dictionary -- a list of strings which count as words"""
-    if start == end:
-        return [start]
-
-    remaining_dictionary = dictionary.copy()
-
-    # bidirectional_bfs expects the words in current_nodes and target_nodes to not be in the dictionary
-    if start in remaining_dictionary:
-        remaining_dictionary.remove(start)
-    if end in remaining_dictionary:
-        remaining_dictionary.remove(end)
-
-    chain = bidirectional_bfs_A([SearchNode(start)], [SearchNode(end)], remaining_dictionary)
-
-    # Bidirectional nature means result may be in opposite order
-    if len(chain) > 0 and chain[0] != start:
-        chain.reverse()
-    return chain
-
-
-def bidirectional_bfs_A(current_nodes, target_nodes, dictionary):
-    """A recursive implementation of Breadth-first search to find a chain"""
-    # Check if this is the last step
-    potential_chain = check_single_step_A(current_nodes, target_nodes)
-    if len(potential_chain) > 0:
-        return potential_chain
-
-    # If a single step was not sufficient, find all adjacent words from the dictionary
-    next_words = []
-    for current_word in current_nodes:
-        adjacent_words = get_adjacent_words(current_word, dictionary)
-        for found_word in adjacent_words:
-            dictionary.remove(found_word)
-        next_words.extend(map(lambda word: SearchNode(word, current_word), adjacent_words))
-
-    # If no adjacent words were found, then there is no path
-    if len(next_words) == 0:
-        return []
-
-    # Otherwise, move on to the next step
-    return bidirectional_bfs(target_nodes, next_words, dictionary)
-
-
-def standard_bfs(start, end, dictionary):
-    if start == end:
-        return [start]
-    remaining_dictionary = dictionary.copy()
-
-    if start in remaining_dictionary:
-        remaining_dictionary.remove(start)
-
-    current_nodes = [SearchNode(start)]
-    while len(current_nodes) > 0:
-        adjacent_nodes = []
-        for node in current_nodes:
-            adjacent_words = get_adjacent_words(node, remaining_dictionary)
-            if end in adjacent_words:
-                history = node.get_list()
-                history.append(end)
-                return history
-            for word in adjacent_words:
-                adjacent_nodes.append(SearchNode(word, node))
-                remaining_dictionary.remove(word)
-        current_nodes = adjacent_nodes
-
-    # If the while loop ends without returning, no chain is possible
-    return []
-
-
 def check_single_step(current_nodes, target_nodes):
     """Returns a chain if any target node is one step from any current node, empty otherwise"""
     for current_node in current_nodes:
@@ -130,26 +59,6 @@ def check_single_step(current_nodes, target_nodes):
                 right_list.reverse()
                 left_list.extend(right_list)
                 return left_list
-    return []
-
-
-def check_single_step_A(left_nodes, right_nodes):
-    """Same as check_single_step, but optimizes based on assuming current_nodes and target_nodes are alphabetized"""
-    left_index = 0
-    right_index = 0
-    while left_index < len(left_nodes) and right_index < len(right_nodes):
-        left_word = left_nodes[left_index].word
-        right_word = right_nodes[right_index].word
-        if left_word == right_word:
-            left_list = left_word.get_list()
-            right_list = right_word.get_list()
-            right_list.reverse()
-            left_list.extend(right_list)
-            return left_list
-        elif left_word < right_word:
-            left_index += 1
-        else:
-            right_index += 1
     return []
 
 

--- a/chainAlgorithm.py
+++ b/chainAlgorithm.py
@@ -4,17 +4,18 @@ def get_chain(start, end, dictionary):
     start -- the first word in the chain
     end -- the last word in the chain
     dictionary -- a list of strings which count as words"""
-    # Immediately
     if start == end:
         return [start]
 
-    # bidirectional_bfs expects the words in current_nodes and target_nodes to not be in the dictionary
-    if start in dictionary:
-        dictionary.remove(start)
-    if end in dictionary:
-        dictionary.remove(end)
+    remaining_dictionary = dictionary.copy()
 
-    chain = bidirectional_bfs([SearchNode(start)], [SearchNode(end)], dictionary)
+    # bidirectional_bfs expects the words in current_nodes and target_nodes to not be in the dictionary
+    if start in remaining_dictionary:
+        remaining_dictionary.remove(start)
+    if end in remaining_dictionary:
+        remaining_dictionary.remove(end)
+
+    chain = bidirectional_bfs([SearchNode(start)], [SearchNode(end)], remaining_dictionary)
 
     # Bidirectional nature means result may be in opposite order
     if len(chain) > 0 and chain[0] != start:
@@ -30,19 +31,93 @@ def bidirectional_bfs(current_nodes, target_nodes, dictionary):
         return potential_chain
 
     # If a single step was not sufficient, find all adjacent words from the dictionary
-    remaining_dictionary = dictionary.copy()
     next_words = []
     for current_word in current_nodes:
-        adjacent_words = get_adjacent_words(current_word, remaining_dictionary)
+        adjacent_words = get_adjacent_words(current_word, dictionary)
         for found_word in adjacent_words:
-            remaining_dictionary.remove(found_word)
+            dictionary.remove(found_word)
         next_words.extend(map(lambda word: SearchNode(word, current_word), adjacent_words))
 
-    # if no adjacent words were found, then there is no path
+    # If no adjacent words were found, then there is no path
     if len(next_words) == 0:
         return []
 
-    return bidirectional_bfs(target_nodes, next_words, remaining_dictionary)
+    # Otherwise, move on to the next step
+    return bidirectional_bfs(target_nodes, next_words, dictionary)
+
+
+def get_chain_A(start, end, dictionary):
+    """Finds a minimum length chain of words with only one character different between each link
+
+    start -- the first word in the chain
+    end -- the last word in the chain
+    dictionary -- a list of strings which count as words"""
+    if start == end:
+        return [start]
+
+    remaining_dictionary = dictionary.copy()
+
+    # bidirectional_bfs expects the words in current_nodes and target_nodes to not be in the dictionary
+    if start in remaining_dictionary:
+        remaining_dictionary.remove(start)
+    if end in remaining_dictionary:
+        remaining_dictionary.remove(end)
+
+    chain = bidirectional_bfs_A([SearchNode(start)], [SearchNode(end)], remaining_dictionary)
+
+    # Bidirectional nature means result may be in opposite order
+    if len(chain) > 0 and chain[0] != start:
+        chain.reverse()
+    return chain
+
+
+def bidirectional_bfs_A(current_nodes, target_nodes, dictionary):
+    """A recursive implementation of Breadth-first search to find a chain"""
+    # Check if this is the last step
+    potential_chain = check_single_step_A(current_nodes, target_nodes)
+    if len(potential_chain) > 0:
+        return potential_chain
+
+    # If a single step was not sufficient, find all adjacent words from the dictionary
+    next_words = []
+    for current_word in current_nodes:
+        adjacent_words = get_adjacent_words(current_word, dictionary)
+        for found_word in adjacent_words:
+            dictionary.remove(found_word)
+        next_words.extend(map(lambda word: SearchNode(word, current_word), adjacent_words))
+
+    # If no adjacent words were found, then there is no path
+    if len(next_words) == 0:
+        return []
+
+    # Otherwise, move on to the next step
+    return bidirectional_bfs(target_nodes, next_words, dictionary)
+
+
+def standard_bfs(start, end, dictionary):
+    if start == end:
+        return [start]
+    remaining_dictionary = dictionary.copy()
+
+    if start in remaining_dictionary:
+        remaining_dictionary.remove(start)
+
+    current_nodes = [SearchNode(start)]
+    while len(current_nodes) > 0:
+        adjacent_nodes = []
+        for node in current_nodes:
+            adjacent_words = get_adjacent_words(node, remaining_dictionary)
+            if end in adjacent_words:
+                history = node.get_list()
+                history.append(end)
+                return history
+            for word in adjacent_words:
+                adjacent_nodes.append(SearchNode(word, node))
+                remaining_dictionary.remove(word)
+        current_nodes = adjacent_nodes
+
+    # If the while loop ends without returning, no chain is possible
+    return []
 
 
 def check_single_step(current_nodes, target_nodes):
@@ -55,6 +130,26 @@ def check_single_step(current_nodes, target_nodes):
                 right_list.reverse()
                 left_list.extend(right_list)
                 return left_list
+    return []
+
+
+def check_single_step_A(left_nodes, right_nodes):
+    """Same as check_single_step, but optimizes based on assuming current_nodes and target_nodes are alphabetized"""
+    left_index = 0
+    right_index = 0
+    while left_index < len(left_nodes) and right_index < len(right_nodes):
+        left_word = left_nodes[left_index].word
+        right_word = right_nodes[right_index].word
+        if left_word == right_word:
+            left_list = left_word.get_list()
+            right_list = right_word.get_list()
+            right_list.reverse()
+            left_list.extend(right_list)
+            return left_list
+        elif left_word < right_word:
+            left_index += 1
+        else:
+            right_index += 1
     return []
 
 


### PR DESCRIPTION
Added code for performing benchmarks so that potential optimizations can be tested. Some such potential optimizations were tried but rejected:
- A simpler standard Breadth-first search may have had reduced overhead, but had much worse performance overall:
![uni_bi](https://user-images.githubusercontent.com/40572238/147373936-050d35ba-10f7-400d-82b6-7ee2c5b14b4f.png)
- A modified method that took advantage of the pre-alphabetized dictionary had such a minor improvement that the previous version was kept in case non-alphabetized dictionaries need to be supported:
![alpha_non](https://user-images.githubusercontent.com/40572238/147373964-065a8206-4b2d-4cd7-a557-39f67463ae1a.png)
